### PR TITLE
[bugfix] make the insufficient eth log work

### DIFF
--- a/contracts/utils.py
+++ b/contracts/utils.py
@@ -142,7 +142,7 @@ async def fund_account(toAddr):
     acc_client, acc_addr = get_account_client()
     if "testnet" in acc_client.net:
         bal = await acc_client.get_balance(data['TESTNET_ETH'])
-        if bal == 0:
+        if bal < data['TRANSFER_AMOUNT']:
             return ""
 
         nonce_payload = data['NONCE_PAYLOAD']
@@ -166,7 +166,7 @@ async def fund_account(toAddr):
 
     else:
         bal = await acc_client.get_balance(data['DEVNET_ETH'])
-        if bal == 0:
+        if bal < data['TRANSFER_AMOUNT']:
             return ""
             
         eth_contract = await Contract.from_address(data['DEVNET_ETH'], acc_client, False)


### PR DESCRIPTION
When the account contract doesn't have sufficient eth, running the hello.py example will encounter something like the below, it is a little bit weird to find out what happened. I fix it. But in some extreme conditions, if the account contract's balance  <  transfer amount + gas_fee, it will still encounter such a weird log. Do you have any suggestions or does this pr seem to be OK ?
```
Your mission:
         1) deploy an account contract with an '__execute__' entrypoint
         2) fetch the 'random' storage_variable from the validator contract
         3) pass 'random' via calldata to your account contract

Found local contract: 0x129ec8f47c1289eb4af9a7d61d12ea4489d12f16ed57ad0a782287b233ed0c4

Traceback (most recent call last):
  File "hello/hello.py", line 53, in <module>
    asyncio.run(main())
  File "/usr/lib/python3.8/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/usr/lib/python3.8/asyncio/base_events.py", line 616, in run_until_complete
    return future.result()
  File "hello/hello.py", line 33, in main
    reward_account = await fund_account(hello_addr)
  File "/home/felix/software/blockchain/starknet/starknet-accounts/contracts/./utils.py", line 163, in fund_account
    await acc_client.wait_for_tx(resp.json()['transaction_hash'])
  File "/home/felix/software/blockchain/starknet/starknet-accounts/env/lib/python3.8/site-packages/starknet_py/net/client.py", line 231, in wait_for_tx
    raise TransactionRejectedError(
starknet_py.transaction_exceptions.TransactionRejectedError: Transaction was rejected with following starknet error: TRANSACTION_FAILED:Error at pc=0:32:
Got an exception while executing a hint.
Cairo traceback (most recent call last):
Unknown location (pc=0:502)
Unknown location (pc=0:461)
Unknown location (pc=0:518)

Error in the called contract (0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7):
Error at pc=0:104:
Got an exception while executing a hint.
Cairo traceback (most recent call last):
Unknown location (pc=0:1678)
Unknown location (pc=0:1664)

Error in the called contract (0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7):
Error at pc=0:9:
Got an exception while executing a hint.
Cairo traceback (most recent call last):
Unknown location (pc=0:1351)
Unknown location (pc=0:1328)
Unknown location (pc=0:915)

Traceback (most recent call last):
  File "<hint1>", line 3, in <module>
AssertionError: assert_not_zero failed: 0 = 0..
```

