### PR TITLE
Update starknet-devnet version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 rich 
 requests
 openzeppelin-cairo-contracts==0.4.0b0
-starknet-devnet==0.3.1
+starknet-devnet==0.4.4
 starknet.py==0.12.0a0
 pytest 
 pytest-asyncio


### PR DESCRIPTION
Versions of `starknet-devnet` and `starknet-py` specified in requirement.txt have different dependency requirement.

```shell
ERROR: Cannot install -r requirements.txt (line 4) and -r requirements.txt (line 5) because these package versions have conflicting dependencies.

The conflict is caused by:
    starknet-devnet 0.3.1 depends on cairo-lang==0.10.0
    starknet-py 0.12.0a0 depends on cairo-lang==0.10.3
```

Updating `starknet-devnet` resolves the issue.